### PR TITLE
Indonesian Stop Words (and a bug fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+*.swp
 .bundle
 .config
 .yardoc

--- a/lib/ruby-tf-idf.rb
+++ b/lib/ruby-tf-idf.rb
@@ -78,6 +78,44 @@ module RubyTfIdf
       'étant','être'
     ]
 
+    STOP_WORDS_ID = [
+      'yang', 'di', 'dan', 'itu', 'dengan', 'untuk', 'tidak', 'ini', 'dari', 'dalam', 'akan',
+      'pada', 'juga', 'saya', 'ke', 'karena', 'tersebut', 'bisa', 'ada', 'mereka', 'lebih',
+      'kata', 'tahun', 'sudah', 'atau', 'saat', 'oleh', 'menjadi', 'orang', 'ia', 'telah',
+      'adalah', 'seperti', 'sebagai', 'bahwa', 'dapat', 'para', 'harus', 'namun', 'kita', 'dua',
+      'satu', 'hari', 'hanya', 'mengatakan', 'kepada', 'kami', 'setelah', 'melakukan',
+      'lalu', 'belum', 'lain', 'dia', 'kalau', 'terjadi', 'banyak', 'menurut', 'anda', 'hingga',
+      'tak', 'baru', 'beberapa', 'ketika', 'saja', 'jalan', 'sekitar', 'secara', 'dilakukan',
+      'sementara', 'tapi', 'sangat', 'hal', 'sehingga', 'seorang', 'bagi', 'besar', 'lagi', 'selama',
+      'antara', 'waktu', 'sebuah', 'jika', 'sampai', 'jadi', 'terhadap', 'tiga', 'serta', 'pun',
+      'salah', 'merupakan', 'atas', 'sejak', 'membuat', 'baik', 'memiliki', 'kembali', 'selain',
+      'tetapi', 'pertama', 'kedua', 'memang', 'pernah', 'apa', 'mulai', 'sama', 'tentang', 'bukan',
+      'agar', 'semua', 'sedang', 'kali', 'kemudian', 'hasil', 'sejumlah', 'juta', 'persen', 'sendiri',
+      'katanya', 'demikian', 'masalah', 'mungkin', 'umum', 'setiap', 'bulan', 'bagian', 'bila', 'lainnya',
+      'terus', 'luar', 'cukup', 'termasuk', 'sebelumnya', 'bahkan', 'wib', 'tempat', 'perlu',
+      'menggunakan', 'memberikan', 'rabu', 'sedangkan', 'kamis', 'langsung', 'apakah', 'pihak', 'melalui',
+      'diri', 'mencapai', 'minggu', 'aku', 'berada', 'tinggi', 'ingin', 'sebelum', 'tengah', 'kini',
+      'tahu', 'bersama', 'depan', 'selasa', 'begitu', 'merasa', 'berbagai', 'mengenai', 'maka', 'jumlah',
+      'masuk', 'katanya', 'mengalami', 'sering', 'ujar', 'kondisi', 'akibat', 'hubungan', 'empat',
+      'paling', 'mendapatkan', 'selalu', 'lima', 'meminta', 'melihat', 'sekarang', 'mengaku', 'mau',
+      'kerja', 'acara', 'menyatakan', 'masa', 'proses', 'tanpa', 'selatan', 'sempat', 'adanya', 'hidup',
+      'datang', 'senin', 'rasa', 'maupun', 'seluruh', 'mantan', 'lama', 'jenis', 'segera', 'misalnya',
+      'mendapat', 'bawah', 'jangan', 'meski', 'terlihat', 'akhirnya', 'jumat', 'punya', 'yakni',
+      'terakhir', 'kecil', 'panjang', 'badan', 'juni', 'jelas', 'jauh', 'tentu', 'semakin', 'tinggal',
+      'kurang', 'mampu', 'posisi', 'asal', 'sekali', 'sesuai', 'sebesar', 'berat', 'dirinya', 'memberi',
+      'pagi', 'sabtu', 'ternyata', 'mencari', 'sumber', 'ruang', 'menunjukkan', 'biasanya', 'nama',
+      'sebanyak', 'utara', 'berlangsung', 'barat', 'kemungkinan', 'yaitu', 'berdasarkan', 'sebenarnya',
+      'cara', 'utama', 'pekan', 'terlalu', 'membawa', 'kebutuhan', 'suatu', 'menerima', 'penting',
+      'tanggal', 'bagaimana', 'terutama', 'tingkat', 'awal', 'sedikit', 'nanti', 'pasti', 'muncul',
+      'lanjut', 'ketiga', 'biasa', 'dulu', 'kesempatan', 'ribu', 'akhir', 'membantu', 'terkait', 'sebab',
+      'menyebabkan', 'khusus', 'bentuk', 'ditemukan', 'diduga', 'mana', 'ya', 'kegiatan', 'sebagian',
+      'tampil', 'hampir', 'bertemu', 'usai', 'berarti', 'keluar', 'pula', 'digunakan', 'justru',
+      'padahal', 'menyebutkan', 'gedung', 'apalagi', 'program', 'milik', 'teman', 'menjalani',
+      'keputusan', 'sumber', 'upaya', 'mengetahui', 'mempunyai', 'berjalan', 'menjelaskan', 'mengambil',
+      'benar', 'lewat', 'belakang', 'ikut', 'barang', 'meningkatkan', 'kejadian', 'kehidupan',
+      'keterangan', 'penggunaan', 'masing-masing', 'menghadapi'
+    ]
+
     attr_accessor :tf, :idf, :tf_idf
 
     def initialize(docs, limit, exclude_stop_words)
@@ -134,6 +172,7 @@ module RubyTfIdf
           if (exlude_stop_words == true)
             tfidf.reject!{ |k| STOP_WORDS_FR.include?(k) == true }
             tfidf.reject!{ |k| STOP_WORDS_EN.include?(k) == true }
+            tfidf.reject!{ |k| STOP_WORDS_ID.include?(k) == true }
           end
           tfidf = Hash[tfidf.sort_by { |k,v| -v }[0..limit-1]]
           @tf_idf.push(tfidf)

--- a/lib/ruby-tf-idf.rb
+++ b/lib/ruby-tf-idf.rb
@@ -135,7 +135,7 @@ module RubyTfIdf
       splitted_docs = []
       docs.each do |d|
         begin
-          splitted_docs << d.downcase!.gsub(/,|\.|\'/,'').split(/\s+/)
+          splitted_docs << d.downcase.gsub(/[^a-z0-9]/,' ').split(/\s+/)
         rescue
         end
       end


### PR DESCRIPTION
Thanks for building this gem. I'm using it for my project with Indonesian documents. I added Indonesian stop words to the listed stop words, and I tried to fix a bug I found when using this gem. Please review the changes :pray:

Changes:
- Added Indonesian stop words, based on [Yudi Wibisono's published Indonesian stop words](https://yudiwbs.wordpress.com/2008/07/23/stop-words-untuk-bahasa-indonesia/)
- Fixed `d.downcase!` into `d.downcase` (without `!`). as the earlier returned `nil` and raises a `NoMethodError` when calling `gsub` (it is caught by the `begin...rescue` blocks though)
- Changed the `gsub` parameters on line 138 in the file `lib/ruby-tf-idf.rb` (the original parameters are not suited for my usage, but I want to know what you think about it)
- Added `*.swp` in `.gitignore` for vim users
